### PR TITLE
Ensure compatibility with Symfony 5

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,8 +24,8 @@ class Configuration implements ConfigurationInterface
     /** {@inheritDoc} */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder;
-        $treeBuilder->root('desperado_xml');
+        $treeBuilder = new TreeBuilder('desperado_xml');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('desperado_xml');
 
         return $treeBuilder;
     }


### PR DESCRIPTION
Getting rid of deprecation message
>  A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.

This patch should be enough to ensure compatibility to Symfony 5 while being BC to older versions.
